### PR TITLE
Fix custom array editing in fallback UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,12 +262,13 @@
               alert("Please create and fill the array first!");
               return;
             }
-            const hasInvalid = this.customArray.some(val => val === '' || isNaN(Number(val)));
+            const convertedArray = this.customArray.map(val => Number(val));
+            const hasInvalid = this.customArray.some((val, idx) => val === '' || isNaN(convertedArray[idx]));
             if (hasInvalid) {
               alert("Please fill every entry with a valid number before sorting.");
               return;
             }
-            this.arr = this.customArray.map(val => Number(val));
+            this.arr = convertedArray;
             this.steps = [];
             this.currentStep = -1;
             this.totalOperations = 0;

--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@
 
             const customInputs = this.isCustomMode && this.customArray.length > 0 ?
               this.customArray.map((val, i) =>
-                `<input type="number" id="element${i}" value="${val}" oninput="window.visualizer.updateArrayElement(${i}, this.value)" style="width: 60px; margin: 2px; padding: 4px; border-radius: 4px; border: 1px solid #555; background: #2a2a2a; color: white;" placeholder="Val">`
+                `<input type="number" id="element${i}" value="${val}" oninput="window.visualizer.updateArrayElement(${i}, this.value)" class="w-16 m-1 p-1 rounded border border-gray-700 bg-zinc-800 text-white" placeholder="Val">`
               ).join('') : '';
 
             const stepInfo = this.currentStep >= 0 ? `

--- a/index.html
+++ b/index.html
@@ -262,7 +262,12 @@
               alert("Please create and fill the array first!");
               return;
             }
-            this.arr = [...this.customArray];
+            const hasInvalid = this.customArray.some(val => val === '' || isNaN(Number(val)));
+            if (hasInvalid) {
+              alert("Please fill every entry with a valid number before sorting.");
+              return;
+            }
+            this.arr = this.customArray.map(val => Number(val));
             this.steps = [];
             this.currentStep = -1;
             this.totalOperations = 0;
@@ -286,22 +291,20 @@
           }
 
           createCustomArray() {
-            const size = parseInt(document.getElementById('arraySize').value);
+            const size = parseInt(document.getElementById('arraySize').value, 10);
             if (size < 1 || size > 20) {
               alert("Please enter array size between 1 and 20");
               return;
             }
             this.customSize = size;
-            this.customArray = new Array(size).fill(0);
+            this.customArray = new Array(size).fill('');
             this.isCustomMode = true;
             this.render();
           }
 
           updateArrayElement(index, value) {
-            const num = parseInt(value);
-            if (!isNaN(num)) {
-              this.customArray[index] = num;
-            }
+            this.customArray[index] = value;
+            this.render();
           }
 
           toggleMode() {
@@ -319,14 +322,22 @@
           }
 
           render() {
-            const currentArray = this.currentStep >= 0 ? this.steps[this.currentStep].array : this.arr;
-            const bars = currentArray.map((v, i) => 
-              `<div class="bg-emerald-500 w-6" style="height: ${Math.max(4 * v, 4)}px; display: inline-block; margin-right: 2px; border-radius: 2px;" title="Value: ${v}"></div>`
-            ).join('');
+            const currentArray = this.currentStep >= 0
+              ? this.steps[this.currentStep].array
+              : (this.isCustomMode && this.customArray.length > 0
+                ? this.customArray.map(v => v === '' || isNaN(Number(v)) ? 0 : Number(v))
+                : this.arr);
+            const bars = currentArray.map((v, i) => {
+              const label = (this.isCustomMode && this.currentStep < 0)
+                ? (this.customArray[i] === '' ? '(empty)' : this.customArray[i])
+                : v;
+              const height = Math.max(4 * (isNaN(Number(v)) ? 0 : Number(v)), 4);
+              return `<div class="bg-emerald-500 w-6" style="height: ${height}px; display: inline-block; margin-right: 2px; border-radius: 2px;" title="Value: ${label}"></div>`;
+            }).join('');
 
-            const customInputs = this.isCustomMode && this.customArray.length > 0 ? 
-              this.customArray.map((val, i) => 
-                `<input type="number" id="element${i}" value="${val}" onchange="window.visualizer.updateArrayElement(${i}, this.value)" style="width: 60px; margin: 2px; padding: 4px; border-radius: 4px; border: 1px solid #555; background: #2a2a2a; color: white;" placeholder="Val">`
+            const customInputs = this.isCustomMode && this.customArray.length > 0 ?
+              this.customArray.map((val, i) =>
+                `<input type="number" id="element${i}" value="${val}" oninput="window.visualizer.updateArrayElement(${i}, this.value)" style="width: 60px; margin: 2px; padding: 4px; border-radius: 4px; border: 1px solid #555; background: #2a2a2a; color: white;" placeholder="Val">`
               ).join('') : '';
 
             const stepInfo = this.currentStep >= 0 ? `

--- a/index.html
+++ b/index.html
@@ -336,7 +336,8 @@
               const label = (this.isCustomMode && this.currentStep < 0)
                 ? (this.customArray[i] === '' ? '(empty)' : this.customArray[i])
                 : v;
-              const height = Math.max(4 * (isNaN(Number(v)) ? 0 : Number(v)), 4);
+              const numV = Number(v);
+              const height = Math.max(4 * (isNaN(numV) ? 0 : numV), 4);
               return `<div class="bg-emerald-500 w-6" style="height: ${height}px; display: inline-block; margin-right: 2px; border-radius: 2px;" title="Value: ${label}"></div>`;
             }).join('');
 

--- a/index.html
+++ b/index.html
@@ -328,16 +328,27 @@
           }
 
           render() {
+            let customArrayNumbers = [];
+            if (this.isCustomMode && this.customArray.length > 0) {
+              customArrayNumbers = this.customArray.map(v => {
+                const num = Number(v);
+                return (v === '' || isNaN(num)) ? 0 : num;
+              });
+            }
             const currentArray = this.currentStep >= 0
               ? this.steps[this.currentStep].array
               : (this.isCustomMode && this.customArray.length > 0
-                ? this.customArray.map(v => v === '' || isNaN(Number(v)) ? 0 : Number(v))
+                ? customArrayNumbers
                 : this.arr);
             const bars = currentArray.map((v, i) => {
-              const label = (this.isCustomMode && this.currentStep < 0)
-                ? (this.customArray[i] === '' ? '(empty)' : this.customArray[i])
-                : v;
-              const numV = Number(v);
+              let label, numV;
+              if (this.isCustomMode && this.currentStep < 0) {
+                label = this.customArray[i] === '' ? '(empty)' : this.customArray[i];
+                numV = customArrayNumbers[i];
+              } else {
+                label = v;
+                numV = Number(v);
+              }
               const height = Math.max(4 * (isNaN(numV) ? 0 : numV), 4);
               return `<div class="bg-emerald-500 w-6" style="height: ${height}px; display: inline-block; margin-right: 2px; border-radius: 2px;" title="Value: ${label}"></div>`;
             }).join('');

--- a/index.html
+++ b/index.html
@@ -291,8 +291,13 @@
           }
 
           createCustomArray() {
-            const size = parseInt(document.getElementById('arraySize').value, 10);
-            if (size < 1 || size > 20) {
+            const arraySizeElem = document.getElementById('arraySize');
+            if (!arraySizeElem || arraySizeElem.value == null || arraySizeElem.value.trim() === '') {
+              alert("Array size input is missing or empty.");
+              return;
+            }
+            const size = parseInt(arraySizeElem.value, 10);
+            if (isNaN(size) || size < 1 || size > 20) {
               alert("Please enter array size between 1 and 20");
               return;
             }

--- a/index.html
+++ b/index.html
@@ -355,7 +355,7 @@
 
             const customInputs = this.isCustomMode && this.customArray.length > 0 ?
               this.customArray.map((val, i) =>
-                `<input type="number" id="element${i}" value="${val}" oninput="window.visualizer.updateArrayElement(${i}, this.value)" class="w-16 m-1 p-1 rounded border border-gray-700 bg-zinc-800 text-white" placeholder="Val">`
+                `<input type="number" id="element${i}" value="${val}" oninput="window.visualizer.updateArrayElement(${i}, this.value)" style="width: 4rem; margin: 0.25rem; padding: 0.25rem; border-radius: 0.25rem; border: 1px solid #374151; background: #27272a; color: #fff;" placeholder="Val">`
               ).join('') : '';
 
             const stepInfo = this.currentStep >= 0 ? `


### PR DESCRIPTION
## Summary
- ensure fallback visualizer preview updates immediately while typing in custom array inputs
- allow custom arrays to start with blank slots and require valid numbers before sorting to avoid stale values

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4aef65b30833181622c1351b0903d