### PR TITLE
Improve fallback custom array editing

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,13 @@
               alert("Please create and fill the array first!");
               return;
             }
-            this.arr = [...this.customArray];
+            const convertedArray = this.customArray.map((val) => Number(val));
+            const hasInvalid = this.customArray.some((val, idx) => val === '' || Number.isNaN(convertedArray[idx]));
+            if (hasInvalid) {
+              alert("Please fill every entry with a valid number before sorting.");
+              return;
+            }
+            this.arr = convertedArray;
             this.steps = [];
             this.currentStep = -1;
             this.totalOperations = 0;
@@ -286,26 +292,24 @@
           }
 
           createCustomArray() {
-            const size = parseInt(document.getElementById('arraySize').value);
-            if (size < 1 || size > 20) {
+            const arraySizeElem = document.getElementById('arraySize');
+            if (!arraySizeElem || arraySizeElem.value == null || arraySizeElem.value.trim() === '') {
+              alert("Array size input is missing or empty.");
+              return;
+            }
+            const size = parseInt(arraySizeElem.value, 10);
+            if (Number.isNaN(size) || size < 1 || size > 20) {
               alert("Please enter array size between 1 and 20");
               return;
             }
             this.customSize = size;
-            this.customArray = new Array(size).fill(0);
+            this.customArray = new Array(size).fill('');
             this.isCustomMode = true;
             this.render();
           }
 
           updateArrayElement(index, value) {
-            if (value === '') {
-              this.customArray[index] = 0;
-            } else {
-              const num = parseInt(value);
-              if (!isNaN(num)) {
-                this.customArray[index] = num;
-              }
-            }
+            this.customArray[index] = value;
             this.render();
           }
 
@@ -324,18 +328,35 @@
           }
 
           render() {
+            let customArrayNumbers = [];
+            if (this.isCustomMode && this.customArray.length > 0) {
+              customArrayNumbers = this.customArray.map((v) => {
+                const num = Number(v);
+                return (v === '' || Number.isNaN(num)) ? 0 : num;
+              });
+            }
             const currentArray = this.currentStep >= 0
               ? this.steps[this.currentStep].array
               : (this.isCustomMode && this.customArray.length > 0
-                ? this.customArray
+                ? customArrayNumbers
                 : this.arr);
-            const bars = currentArray.map((v, i) => 
-              `<div class="bg-emerald-500 w-6" style="height: ${Math.max(4 * v, 4)}px; display: inline-block; margin-right: 2px; border-radius: 2px;" title="Value: ${v}"></div>`
-            ).join('');
+            const bars = currentArray.map((v, i) => {
+              let label;
+              let numericValue;
+              if (this.isCustomMode && this.currentStep < 0) {
+                label = this.customArray[i] === '' ? '(empty)' : this.customArray[i];
+                numericValue = customArrayNumbers[i];
+              } else {
+                label = v;
+                numericValue = Number(v);
+              }
+              const height = Math.max(4 * (Number.isNaN(numericValue) ? 0 : numericValue), 4);
+              return `<div class="bg-emerald-500 w-6" style="height: ${height}px; display: inline-block; margin-right: 2px; border-radius: 2px;" title="Value: ${label}"></div>`;
+            }).join('');
 
-            const customInputs = this.isCustomMode && this.customArray.length > 0 ? 
-              this.customArray.map((val, i) => 
-                `<input type="number" id="element${i}" value="${val}" onchange="window.visualizer.updateArrayElement(${i}, this.value)" style="width: 60px; margin: 2px; padding: 4px; border-radius: 4px; border: 1px solid #555; background: #2a2a2a; color: white;" placeholder="Val">`
+            const customInputs = this.isCustomMode && this.customArray.length > 0 ?
+              this.customArray.map((val, i) =>
+                `<input type="number" id="element${i}" value="${val}" oninput="window.visualizer.updateArrayElement(${i}, this.value)" style="width: 4rem; margin: 0.25rem; padding: 0.25rem; border-radius: 0.25rem; border: 1px solid #374151; background: #27272a; color: #fff;" placeholder="Val">`
               ).join('') : '';
 
             const stepInfo = this.currentStep >= 0 ? `


### PR DESCRIPTION
## Summary
- validate custom fallback arrays before sorting and keep numbers parsed safely
- allow the fallback editor to show empty slots while typing and keep inputs responsive
- render custom entries with readable labels while preserving numeric bar heights

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d4cabb4d688331acb24094942d49d4